### PR TITLE
Do dark frame analysis per channel

### DIFF
--- a/iss_preprocess/image/correction.py
+++ b/iss_preprocess/image/correction.py
@@ -36,8 +36,8 @@ def analyze_dark_frames(fname):
         fname (str): path to dark frame TIFF file
 
     Returns:
-        Mean (np.array): Average black level per channel
-        STD (np.array): Readout noise per channel
+        numpy.array: Average black level per channel
+        numpy.array: Readout noise per channel
 
     """
     images = []


### PR DESCRIPTION
The previous implementation assumed all channels were the same. That might not always be a good idea. (but first test looked like it is not an issue with the current setup)